### PR TITLE
refactor: Add reusable httpx.AsyncClient to IndexManager to avoid 'Transport closed' errors

### DIFF
--- a/src/acemcp/tools/__init__.py
+++ b/src/acemcp/tools/__init__.py
@@ -1,6 +1,5 @@
 """MCP tools for codebase indexing."""
 
-from acemcp.tools.search_context import search_context_tool
+from acemcp.tools.search_context import search_context_tool, shutdown_index_manager
 
-__all__ = ["search_context_tool"]
-
+__all__ = ["search_context_tool", "shutdown_index_manager"]

--- a/src/acemcp/tools/search_context.py
+++ b/src/acemcp/tools/search_context.py
@@ -1,11 +1,56 @@
 """Search context tool for MCP server."""
 
+from __future__ import annotations
+
+import asyncio
 from typing import Any
 
 from loguru import logger
 
 from acemcp.config import get_config
 from acemcp.index import IndexManager
+
+_index_manager: IndexManager | None = None
+_index_manager_lock: asyncio.Lock | None = None
+
+
+async def _get_index_manager() -> IndexManager:
+    """Create or return the shared IndexManager instance."""
+    global _index_manager, _index_manager_lock
+
+    if _index_manager is not None:
+        return _index_manager
+
+    if _index_manager_lock is None:
+        _index_manager_lock = asyncio.Lock()
+
+    async with _index_manager_lock:
+        if _index_manager is None:
+            config = get_config()
+            _index_manager = IndexManager(
+                config.index_storage_path,
+                config.base_url,
+                config.token,
+                config.text_extensions,
+                config.batch_size,
+                config.max_lines_per_blob,
+                config.exclude_patterns,
+            )
+
+    return _index_manager
+
+
+async def shutdown_index_manager() -> None:
+    """Close the shared IndexManager instance."""
+    global _index_manager, _index_manager_lock
+
+    if _index_manager_lock is None:
+        _index_manager_lock = asyncio.Lock()
+
+    async with _index_manager_lock:
+        if _index_manager is not None:
+            await _index_manager.close()
+            _index_manager = None
 
 
 async def search_context_tool(arguments: dict[str, Any]) -> dict[str, Any]:
@@ -31,16 +76,7 @@ async def search_context_tool(arguments: dict[str, Any]) -> dict[str, Any]:
 
         logger.info(f"Tool invoked: search_context for project {project_root_path} with query: {query}")
 
-        config = get_config()
-        index_manager = IndexManager(
-            config.index_storage_path,
-            config.base_url,
-            config.token,
-            config.text_extensions,
-            config.batch_size,
-            config.max_lines_per_blob,
-            config.exclude_patterns,
-        )
+        index_manager = await _get_index_manager()
         result = await index_manager.search_context(project_root_path, query)
 
         return {"type": "text", "text": result}
@@ -48,4 +84,3 @@ async def search_context_tool(arguments: dict[str, Any]) -> dict[str, Any]:
     except Exception as e:
         logger.exception("Error in search_context_tool")
         return {"type": "text", "text": f"Error: {e!s}"}
-

--- a/src/acemcp/web/app.py
+++ b/src/acemcp/web/app.py
@@ -206,5 +206,11 @@ def create_app() -> FastAPI:
         finally:
             log_broadcaster.remove_client(queue)
 
-    return app
+    @app.on_event("shutdown")
+    async def shutdown_tools() -> None:
+        """Release shared tool resources when the web app stops."""
+        from acemcp.tools import shutdown_index_manager
 
+        await shutdown_index_manager()
+
+    return app


### PR DESCRIPTION
- Add reusable httpx.AsyncClient to IndexManager to avoid 'Transport closed' errors
- Implement singleton pattern for IndexManager with proper lifecycle management
- Add shutdown_index_manager() for graceful cleanup across server and web app
- Update search_context tool to use shared IndexManager instance with asyncio lock
- Ensure proper cleanup in server shutdown and FastAPI shutdown event
This pull request addresses connection management issues in the IndexManager class, primarily fixing the 'Transport closed' error that occurs during the second tool call in the Codex environment